### PR TITLE
Ignore internal make targets

### DIFF
--- a/elao.app_symfony_flex/.manala/make/Makefile.tmpl
+++ b/elao.app_symfony_flex/.manala/make/Makefile.tmpl
@@ -25,9 +25,11 @@ include .manala/make/make.release.mk
 HELP += $(call help_section,Release)
 
 {{ range $env, $options := .release }}
+{{ if ne ($env | substr 0 1) "_" }}
 HELP += $(call help,release@{{ $env }},Release in {{ $env }})
 release@{{ $env }}:
 	$(call release,{{ $env }})
+{{ end }}
 {{ end -}}
 
 ##########
@@ -39,9 +41,11 @@ include .manala/make/make.deploy.mk
 HELP += $(call help_section,Deploy)
 
 {{ range $env, $options := .deploy }}
+{{ if ne ($env | substr 0 1) "_" }}
 HELP += $(call help,deploy@{{ $env }},Deploy in {{ $env }})
 deploy@{{ $env }}:
 	$(call deploy,{{ $env }})
+{{ end }}
 {{ end -}}
 
 ###########


### PR DESCRIPTION
This allow to add internal deplay and release targets : 

```
release:
  _all:
    vars: &release_all_vars
      original_commit_prefix: https://github.com/...
      release_dir: /srv/.manala/build/release
      release_repo: git@...
      release_add:
        - bin
        - config
        - public
        - src
        - templates
        - translations
        - var/.gitkeep
        - var/init
        - vendor
        - composer.json
        - composer.lock
        - Makefile
        - .env.local.php
  staging:
    vars:
      << : *release_all_vars
      release_tasks:
        - echo '<?php return [];' > .env.local.php
        - make install@staging
        - make build@staging
      release_version: staging
  production:
    vars:
      << : *release_all_vars
      release_tasks:
        - echo '<?php return [];' > .env.local.php
        - make install@production
        - make build@production
      release_version: production
```